### PR TITLE
Removed OpenMP in external/kmeans

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,14 +6,6 @@ if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
 endif ()
 
-if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-  set(OpenMP_C_FLAGS "-Xpreprocessor -fopenmp")
-  set(OpenMP_C_LIB_NAMES "omp")
-  set(OpenMP_omp_LIBRARY omp)
-else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp")
-endif ()
-
 MESSAGE(STATUS "CMAKE_BUILD_TYPE: " ${CMAKE_BUILD_TYPE})
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -34,7 +26,7 @@ if (UNIX)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ggdb")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-missing-braces -Wno-unknown-attributes -Wno-unused-function")
 
-  MESSAGE(STATUS "Compiling with flags: ${CMAKE_CXX_FLAGS}")
+  MESSAGE(STATUS "Compiling with flags:${CMAKE_CXX_FLAGS}")
 
   # Flags for PTHash:
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread") # for multi-threading

--- a/include/builders/differential_builder.hpp
+++ b/include/builders/differential_builder.hpp
@@ -187,7 +187,7 @@ private:
             params.set_max_iteration(max_iteration);
             params.set_min_cluster_size(min_cluster_size);
             params.set_random_seed(seed);
-
+            params.set_num_threads(m_build_config.num_threads);
             clustering_data = kmeans::kmeans_divisive(points.begin(), points.end(), params);
         }
 

--- a/include/builders/meta_builder.hpp
+++ b/include/builders/meta_builder.hpp
@@ -60,6 +60,7 @@ struct permuter {
             params.set_max_iteration(max_iteration);
             params.set_min_cluster_size(min_cluster_size);
             params.set_random_seed(seed);
+            params.set_num_threads(m_build_config.num_threads);
             auto clustering_data = kmeans::kmeans_divisive(points.begin(), points.end(), params);
 
             timer.stop();


### PR DESCRIPTION
Do not use OpenMP (third-party libraries) and just rely on native C++ threads.